### PR TITLE
Upgrade to aws sdk 1.12.138

### DIFF
--- a/aws-java-sdk-dynamodb/pom.xml
+++ b/aws-java-sdk-dynamodb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.762-dw4-SNAPSHOT</version>
+    <version>1.12.138-dw-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.amazonaws</groupId>
@@ -15,6 +15,13 @@
 
   <!-- The dependencies section in pom.xml is auto generated. No manual changes are allowed -->
   <dependencies>
+
+    <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
+    </dependency>
+
     <dependency>
         <artifactId>aws-java-sdk-s3</artifactId>
         <groupId>com.amazonaws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-java-sdk-pom</artifactId>
-  <version>1.11.762-dw4-SNAPSHOT</version>
+  <version>1.12.138-dw-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>AWS SDK for Java</name>
   <description>The Amazon Web Services SDK for Java provides Java APIs
@@ -263,7 +263,7 @@
   </scm>
   <properties>
       <awsjavasdk.version>${project.version}</awsjavasdk.version>
-      <awsjavasdk-stable.version>1.11.762</awsjavasdk-stable.version>
+      <awsjavasdk-stable.version>1.12.138</awsjavasdk-stable.version>
       <!-- The SDK requires Jackson 2.6 to support Java 6 customers. Feel free to override in your own application -->
       <jackson.version>2.6.7</jackson.version>
       <jackson.databind.version>2.6.7.3</jackson.databind.version>
@@ -303,6 +303,11 @@
         <groupId>com.amazonaws</groupId>
         <artifactId>jmespath-java</artifactId>
         <version>${awsjavasdk-stable.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+          <version>1.3.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Ticket: https://dataworld.atlassian.net/browse/DWCC-103

Main change here is to add a dependency on `javax.annotation`, which is no longer available in JRE post-java8.